### PR TITLE
Reduce gulp file by using gulp-load-plugins.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,13 +1,13 @@
 console.time('require');
 import gulp from 'gulp';
-import stylus from 'gulp-stylus';
-import uglify from 'gulp-uglify';
-import imagemin from 'gulp-imagemin';
+import gulpLoadPlugins from 'gulp-load-plugins';
 console.timeEnd('require');
+
+const $ = gulpLoadPlugins();
 
 gulp.task('css', () => {
   return gulp.src('./src/css/*.styl')
-    .pipe(stylus({
+    .pipe($.stylus({
       compress: true
     }))
     .pipe(gulp.dest('./build/css'));
@@ -15,13 +15,13 @@ gulp.task('css', () => {
 
 gulp.task('js', () => {
   return gulp.src('./src/js/*.js')
-    .pipe(uglify())
+    .pipe($.uglify())
     .pipe(gulp.dest('./build/js'));
 });
 
 gulp.task('img', () => {
   return gulp.src('./src/img/*')
-    .pipe(imagemin({
+    .pipe($.imagemin({
         progressive: true,
         svgoPlugins: [{removeViewBox: false}],
     }))

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-core": "^5.8.25",
     "gulp": "^3.9.0",
     "gulp-imagemin": "^2.3.0",
+    "gulp-load-plugins": "^0.10.0",
     "gulp-stylus": "^2.0.7",
     "gulp-uglify": "^1.4.1"
   }


### PR DESCRIPTION
Can reduce the number of `import` statements with `gulp-load-plugins`.
